### PR TITLE
Allow units for specification

### DIFF
--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -474,19 +474,15 @@
                       &nbsp;<span tal:content="structure python:sample.get_formatted_uncertainty(analysis)"/>
                     </tal:result_uncertainty>
                   </td>
-                  <td>
+                  <td class=" text-nowrap">
                       <!-- Range interval or range comment -->
-                      <span tal:define="normal_values python:view.get_normal_values(model, analysis);"
-                            tal:condition="normal_values"
-                            tal:content="normal_values"/>
+                    <tal:normal_values define="normal_values python:view.get_normal_values(model, analysis);"
+                                       condition="normal_values">
 
-                      <tal:result_unit condition="analysis/Unit">
-                      &nbsp;<span class="units font-italic"
-                            tal:define="show_normal_unit python:view.show_normal_unit(model, analysis);"
-                            tal:condition="show_normal_unit"
+                      <span tal:content="normal_values"/>
+                      <span class="units font-italic"
                             tal:content="structure python:sample.get_formatted_unit(analysis)"/>
-                      </tal:result_unit>
-
+                    </tal:normal_values>
                   </td>
                   <td>
                       <!-- Out of range symbol -->

--- a/src/palau/lims/impress/reportview.py
+++ b/src/palau/lims/impress/reportview.py
@@ -465,10 +465,3 @@ class DefaultReportView(SingleReportView):
         submitters = self.get_submitters(model)
         submitters = map(self.get_user_properties, submitters)
         return filter(None, submitters)
-
-    def show_normal_unit(self, model, analysis):
-        """Returns True if a Normal Value Exists and determines whether
-        the Unit in the Normal Value should be displayed or not."""
-        if self.get_normal_values(model, analysis):
-            return True
-        return False


### PR DESCRIPTION
## Description
This pull request adds default units to specification table and on final report under normal values
Linked issue: #34 

## Current behavior
Unable to add units in specification table set up

## Desired behavior
Default units are added to specification table and then on final report under normal values

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
