### PR TITLE
Skip inactive specifications on sample registration validation

### DIFF
--- a/src/palau/lims/adapters/addsample.py
+++ b/src/palau/lims/adapters/addsample.py
@@ -76,7 +76,8 @@ class RecordsValidator(object):
         sample_type_uid = record.get("SampleType")
         query = {
             "portal_type": "AnalysisSpec",
-            "sampletype_uid": sample_type_uid
+            "sampletype_uid": sample_type_uid,
+            "is_active": True,
         }
         specs = api.search(query, SETUP_CATALOG)
         if len(specs):


### PR DESCRIPTION
## Description

This Pull Request fixes an issue that went unnoticed in #46 , so system is complaining that "Specifications" field is required for sample types without active specifications, but with inactive ones.

Linked issue: https://github.com/beyondessential/palau.lims/issues/35#issuecomment-1763517690

## Current behavior

User gets a "Specification is required" when creating a sample with a sample type that has no active specifications assigned, but inactive

## Desired behavior

Sample is created successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
