### PR TITLE
Shows Normal Values Heading when needed

### DIFF
--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -408,8 +408,13 @@
                 <th tal:repeat="var_name vars_names"
                     tal:content="var_name"/>
                 <th i18n:translate="">Result</th>
-                <th i18n:translate="" colspan="2" tal:condition="python: view.show_header(analyses)">Normal values</th>
-                <th i18n:translate="" colspan="2" tal:condition="python: not view.show_header(analyses)"> </th>
+                <th colspan="2">
+                  <tal:n i18n:translate=""
+                         define="normal_values python:[view.get_normal_values(model, analysis) for analysis in analyses]"
+                         condition="python: any(normal_values)">
+                    Normal values
+                  </tal:n>
+                </th>
               </tr>
               </thead>
               <tbody>

--- a/src/palau/lims/impress/reportview.py
+++ b/src/palau/lims/impress/reportview.py
@@ -465,18 +465,3 @@ class DefaultReportView(SingleReportView):
         submitters = self.get_submitters(model)
         submitters = map(self.get_user_properties, submitters)
         return filter(None, submitters)
-
-    def has_range(self, analysis):
-        """Returns a Boolean value and checks whether the analysis has
-         min/max values or not"""
-        if analysis.getResultsRange():
-            return True
-        return False
-
-    def show_header(self, analyses):
-        """Returns a Boolean value indicating whether to display the Normal
-        Values header in the final report"""
-        for analysis in analyses:
-            if self.has_range(analysis):
-                return True
-        return False


### PR DESCRIPTION
## Description
This pull request ensures that the 'Normal Values' header in the final report is displayed only when analyses with specifications are set up.
Linked issue: #49 

## Current behavior
Heading Normal values appear when no normal values to report

## Desired behavior
Only shows the 'Normal Values' header when analyses with specifications set up are being reported in final report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
