### PR TITLE
Add subscribers to tamanu module

### DIFF
--- a/src/palau/lims/tamanu/subscribers/__init__.py
+++ b/src/palau/lims/tamanu/subscribers/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS
+#
+# Copyright 2020-2023 Beyond Essential Systems Pty Ltd

--- a/src/palau/lims/tamanu/subscribers/configure.zcml
+++ b/src/palau/lims/tamanu/subscribers/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="palau.lims">
+
+  <!-- Patient: Dexterity Object Created -->
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".patient.modifiedPatient"
+      />
+
+  <!-- Patient: Dexterity Object Modified -->
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".patient.modifiedPatient"
+      />
+</configure>

--- a/src/palau/lims/tamanu/subscribers/patient.py
+++ b/src/palau/lims/tamanu/subscribers/patient.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS
+#
+# Copyright 2020-2023 Beyond Essential Systems Pty Ltd
+
+from bika.lims import api
+from bika.lims.api import security
+from Products.CMFCore.permissions import ModifyPortalContent
+
+
+def modifiedPatient(obj, event):
+    """Patient was modified, cloned or created
+    """
+    username = api.get_current_user().id
+    if username == "tamanu":
+        security.grant_local_roles_for(obj, "Owner", username)
+        roles = security.get_valid_roles_for(obj)
+        security.revoke_permission_for(obj, ModifyPortalContent, roles)
+        obj.reindexObject()


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/palau.lims/issues/80

## Current behavior
Other roles are be able to add/edit patients

## Desired behavior
Integration with Tamanu only created by Tamanu, other roles shouldn't be able to add/edit patients

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
