### PR TITLE
Reduce the chance of transaction conflicts on Tamanu synchronization

### DIFF
--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -46,6 +46,10 @@ parser.add_argument(
     help="User and password in the <username>:<password> form"
 )
 parser.add_argument(
+    "-su", "--senaite_user",
+    help="SENAITE user"
+)
+parser.add_argument(
     "-r", "--resource",
     help="Resource type to sync. Supported: Patient, ServiceRequest"
 )
@@ -629,7 +633,8 @@ def main(app):
         error("Resource type is missing or not valid")
 
     # Setup environment
-    setup_script_environment(app, stream_out=False, username=USERNAME)
+    username = args.senaite_user or USERNAME
+    setup_script_environment(app, stream_out=False, username=username)
 
     # Start a session with Tamanu server
     session = TamanuSession(host)


### PR DESCRIPTION
## Description

This Pull Request makes the synchronization script to perform a single transaction each time a service request or patient from tamanu is synchronized in SENAITE.

Linked issue: #198

## Current behavior

The synchronization of service requests is delayed quite often due to transaction conflicts

## Desired behavior

The synchronization of service requests is delayed quite often due to transaction conflicts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
