### PR TITLE
Improve the sync with Tamanu with the use of a cache

### DIFF
--- a/scripts/sync_tamanu.py
+++ b/scripts/sync_tamanu.py
@@ -411,7 +411,7 @@ def sync_patients(session, since):
 
     total = len(resources)
     for num, resource in enumerate(resources):
-        if num and num % 100 == 0:
+        if num and num % 10 == 0:
             logger.info("Processing patients {}/{}".format(num, total))
 
         # create or update the patient counterpart at SENAITE
@@ -421,12 +421,14 @@ def sync_patients(session, since):
 @retriable(sync=True)
 def sync_patient(resource):
     mrn = resource.get_mrn() or "unk"
-    logger.info("Processing Patient '{}' ({})".format(mrn, resource.UID))
+    hash = "%s %s" % (mrn, resource.UID)
 
     # skip if up-to-date in our temp cache
     if is_up_to_date(resource):
-        logger.info("Skip %s. Patient is up-to-date with cache" % mrn)
+        logger.info("Skip %s. Patient is up-to-date with cache" % hash)
         return
+
+    logger.info("Processing Patient '{}' ({})".format(mrn, resource.UID))
 
     # get/create the patient
     patient = get_patient(resource)


### PR DESCRIPTION
## Description

This Pull Request adds a temporary cache to boost the synchronization of resources between SENAITE and Tamanu. System stores a mapping between Tamanu resource UIDs and their update dates. On remote resource retrieval, the system checks if the date stored in temporary cache is older than the retrieved one. If so, the system updates the resource as usual. Otherwise, the resource is skipped without the need of full data retrieval from remote server.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
