### PR TITLE
Port flat listing for default, due, received, to be verified and verified samples to bes.lims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #249 Port flat listing for default, due, received, to be verified and verified samples to bes.lims
 - #248 Display clinical information in results report
 - #247 Added collector name in sample barcode labels
 - #246 Capture specimen collector from Tamanu

--- a/src/palau/lims/adapters/listing/samples.py
+++ b/src/palau/lims/adapters/listing/samples.py
@@ -52,21 +52,6 @@ ADD_STATUSES = [
 
 # Statuses to update. List of tuples (status_id, {properties})
 UPDATE_STATUSES = [
-    ("default", {
-        "flat_listing": True,
-    }),
-    ("sample_due", {
-        "flat_listing": True,
-    }),
-    ("sample_received", {
-        "flat_listing": True,
-    }),
-    ("to_be_verified", {
-        "flat_listing": True,
-    }),
-    ("verified", {
-        "flat_listing": True,
-    })
 ]
 
 


### PR DESCRIPTION
## Description

> [!IMPORTANT]  
> Requires https://github.com/beyondessential/bes.lims/pull/31

This Pull Request removes flat listing for default, due, received, to be verified and verified samples from this add-on.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
