### PR TITLE
Map Mixed XP assay

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.0.0 (Unreleased)
 ------------------
-
+- #251 Map Mixed XP assay in XP-100
 - #250 Compatibility with core#2692 (Refactor sticker functionality)
 - #249 Port flat listing for default, due, received, to be verified and verified samples to bes.lims
 - #248 Display clinical information in results report

--- a/src/palau/lims/astm/sysmex/xp100.py
+++ b/src/palau/lims/astm/sysmex/xp100.py
@@ -40,6 +40,8 @@ KEYWORDS_MAPPING = (
     ("NEUT%", ["Neutrophils"]),
     ("RBC", ["RBC_BF", "Red-CC", "RBC", "RPBC"]),
     ("WBC", ["WBC_BF", "White-CC", "WBC", "PWBC", "WC"]),
+    ("MXD%", ["MXD"]),
+    ("MXD#", ["MXDA"]),
 )
 
 


### PR DESCRIPTION
## Description

Linked issue: https://github.com/beyondessential/palau.lims/issues/251

## Current behavior
Unable to add % in keyword when creating new analysis

## Desired behavior
map assay MXD% from the XP-100 with analysis Mixed % (MXD) and assay MXD# from XP-100 with Analysis Mixed (MXDA)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
