### PR TITLE
Added consumer for Cepheid's GeneXpert

### DIFF
--- a/src/palau/lims/astm/cepheid/configure.zcml
+++ b/src/palau/lims/astm/cepheid/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Chepeid's GeneXpert -->
+  <adapter name="GeneXpert" factory=".genexpert.ASTMImporter"/>
+
+</configure>

--- a/src/palau/lims/astm/cepheid/genexpert.py
+++ b/src/palau/lims/astm/cepheid/genexpert.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PALAU.LIMS.
+#
+# PALAU.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2023-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from palau.lims.astm import ASTMBaseImporter as Base
+
+# 4. test_id:             Chlamydia       Gonorrhea     HBV-VL
+# 5. test_name:           Xpert CT_NG     Xpert CT_NG   Xpert HBV Viral Load
+# 6. test_version:        3               3             1
+# 7. analyte_name         CT              NG
+# 8. complementary_name
+
+KEYWORDS_MAPPING = (
+    # Tuple of (instrument_parameter, (service_keywords))
+    # R|1|^CTNG^^Chlamydia^Xpert CT_NG^3^CT^|NOT DETECTED^||
+    ("Chlamyidia", []),
+    ("CT", []),
+    # R|11|^CTNG^^Gonorrhea^Xpert CT_NG^3^NG^|NOT DETECTED^||
+    ("Gonorrhea", ["Gonorrhea"]),
+    ("NG", ["Gonorrhea"]),
+    # R|1|^^^HBV-VL^Xpert HBV Viral Load^1^^|^22.21|IU/mL|
+    ("HBV-VL", ["HBV-VL"]),
+    # R|1|^^^HCV-VL^Xpert_HCV Viral Load^1^^|NOT DETECTED^|IU/mL|
+    ("HCV-VL", ["HCV-VL"]),
+    # R|1|^^^HIV-VL^Xpert_HIV-1 Viral Load^1^^|^47473.65|copies/mL|
+    ("HIV-VL", ["HIV-VL"]),
+    # R|1|^XpertRES^^XpertCov^Xpress SARS-CoV-2_Flu_RSV plus^1^SARS-CoV-2^|NEGATIVE^||
+    ("XpertCov", ["XpertCov", "COVID-RT-PCR", "COVID-RDT"]),
+    ("SARS-CoV-2", ["XpertCov", "COVID-RT-PCR", "COVID-RDT"]),
+    # R|8|^XpertRES^^XpertFluA^Xpress SARS-CoV-2_Flu_RSV plus^1^Flu A^|NEGATIVE^||
+    ("XpertFluA", ["XpertFluA"]),
+    ("Flu A", ["XpertFluA"]),
+    # R|18|^XpertRES^^XpertFluB^Xpress SARS-CoV-2_Flu_RSV plus^1^Flu B^|NEGATIVE^||
+    ("XpertFluB", ["XpertFluB"]),
+    ("Flu B", ["XpertFluB"]),
+    # R|25|^XpertRES^^XpertRSV^Xpress SARS-CoV-2_Flu_RSV plus^1^RSV^|NEGATIVE^||
+    ("XpertRSV", ["XpertRSV"]),
+    ("RSV", ["XpertRSV"]),
+    # R|1|^X-Carba^^IMP^Xpert_Carba-R^1^IMP^|NOT DETECTED^||
+    ("IMP", []),
+    # R|8|^X-Carba^^VIM^Xpert_Carba-R^1^VIM^|NOT DETECTED^||
+    ("VIM", []),
+    # R|15|^X-Carba^^NDM^Xpert_Carba-R^1^NDM^|NOT DETECTED^||
+    ("NDM", []),
+    # R|22|^X-Carba^^KPC^Xpert_Carba-R^1^KPC^|NOT DETECTED^||
+    ("KPC", []),
+    # R|29|^X-Carba^^OXA48^Xpert_Carba-R^1^OXA48^|NOT DETECTED^||
+    ("OXA48", []),
+)
+
+
+class ASTMImporter(Base):
+    """Results importer for Cepheid GeneXpert
+    """
+
+    @property
+    def keywords_mapping(self):
+        return dict(KEYWORDS_MAPPING)
+
+    def get_sender(self):
+        """Return the instrument name, serial and version
+
+        :returns: Tuple of instrument name, serial, version
+        """
+        header = self.get_header()
+        if not header:
+            return None
+        sender = header.get("sender", {})
+        name = sender.get("name", "")
+        serial = sender.get("id", "")
+        version = sender.get("software_version", "")
+        return name, serial, version
+
+    def get_patient(self):
+        """Returns the (P)atient record of this astm message
+        """
+        patients = self.get_patients()
+        if len(patients) != 1:
+            return {}
+        return patients[0]
+
+    def get_sample_id(self, default=None):
+        """Get the Sample ID
+        """
+        sample_id = super(ASTMImporter, self).get_sample_id(default=default)
+        if sample_id:
+            return sample_id
+
+        # Fallback to patient record's practice_id
+        patient = self.get_patient()
+        if not patient:
+            return default
+
+        # Fallback to Patient ID 1
+        pid = patient.get("id")
+        if pid:
+            return pid
+
+        # Fallback to Patient ID 2 (Practice-assigned ID)
+        pid = patient.get("practice_id")
+        if pid:
+            return pid
+
+        return default
+
+    def is_main_result(self, record):
+        """Returns whether the result record is a main result
+        """
+        test = record.get("test")
+        if not test:
+            return False
+
+        # must have both name and version
+        name = test.get("test_name")
+        version = test.get("test_version")
+        if not all([name, version]):
+            return False
+
+        # and complementary name must be empty
+        complementary = test.get("complementary_name")
+        if complementary:
+            return False
+
+        return True
+
+    def get_results(self):
+        """Return the (R)esult records that are considered as main results
+        """
+        results = super(ASTMImporter, self).get_results()
+        # purge analyte and complementary results
+        return [result for result in results if self.is_main_result(result)]
+
+    def get_test_result(self, record):
+        """Returns the qualitative or quantitative result of the result record
+        """
+        value = record.get("value") or {}
+        qualitative = value.get("qualitative_result")
+        if qualitative:
+            return qualitative
+        return value.get("quantitative_result") or ""
+
+    def get_test_id(self, record):
+        """Returns the test ID from the given results record
+        """
+        test = record.get("test") or {}
+
+        # give priority to the analyte_name over test_id
+        analyte_name = test.get("analyte_name")
+        if analyte_name:
+            return analyte_name
+
+        # fall-back to test_id
+        return test.get("test_id") or ""

--- a/src/palau/lims/astm/configure.zcml
+++ b/src/palau/lims/astm/configure.zcml
@@ -1,6 +1,7 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
   <!-- Package includes -->
+  <include package=".cepheid" />
   <include package=".siemens" />
   <include package=".sysmex" />
 


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Requirements:
> - https://github.com/senaite/senaite.astm/pull/23

This Pull Request adds an ASTM consumer adapter for GeneXpert

## Current behavior

No support for GeneXpert

## Desired behavior

Support for GeneXpert

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
