### PR TITLE
Updated attachment rendering condition to display attachments

### DIFF
--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -608,7 +608,7 @@
   </tal:render>
 
   <!-- ATTACHMENTS -->
-  <tal:render condition="python:False">
+  <tal:render condition="python:True">
     <div class="row section-attachments no-gutters">
       <tal:attachment tal:define="attachments python:model.get_sorted_attachments('r');">
         <h2 i18n:translate=""


### PR DESCRIPTION
## Description
This PR addresses the issue where attachments (such as PDFs) added to a sample when "Render in report" is marked
Linked issue: https://github.com/beyondessential/bes.lims/issues/14

## Current behavior
When an attachment is added to a sample and "Render in report" is selected, the attachment does not appear in the generated report

## Desired behavior
When a sample has an attachment and "Render in report" is selected, the attachment should be displayed in the report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
