### PR TITLE
Update condition check for invalid report in Default.pt template

### DIFF
--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -232,7 +232,7 @@
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Sample has been invalidated due to erroneously published results</div>
           <tal:invalidreport tal:define="child python:model.getRetest()"
-                             tal:condition="child">
+                             tal:condition="python:child">
             <span i18n:translate="">This Sample has been replaced by</span>
             <a tal:attributes="href child/absolute_url"
                tal:content="child/getId"/>


### PR DESCRIPTION
## Description
This PR updates the TAL template in Default.pt to ensure the condition for the `<tal:invalidreport>` block uses the correct Python expression syntax

## Current behavior
The `<tal:invalidreport>` block uses `tal:condition="child"`, which is not explicit and may not always evaluate as intended in TAL templates.

## Desired behavior
Update the condition to `tal:condition="python:child"` for clarity and correctness, ensuring the block is rendered only when child is truthy according to Python evaluation rules.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
