### PR TITLE
Port Collector field addition to bes.lims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #260 Port Collector field addition to bes.lims
 - #259 Update condition check for invalid report in Default.pt template
 - #258 Compatibility with bes#14 (Merge PDF attachments into results report)
 - #256 Port Tamanu synchronization logic to bes.lims

--- a/src/palau/lims/content/analysisrequest.py
+++ b/src/palau/lims/content/analysisrequest.py
@@ -56,7 +56,6 @@ from senaite.core.browser.widgets import QuerySelectWidget
 from senaite.core.browser.widgets import ReferenceWidget
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.permissions import FieldEditSamplePoint
-from senaite.core.permissions import FieldEditSampler
 from zope.component import adapts
 from zope.interface import implementer
 
@@ -415,23 +414,6 @@ NEW_FIELDS = [
                     "label": _(u"Description"),
                 },
             ],
-        )
-    ),
-
-    ExtStringField(
-        "Collector",
-        default="",
-        mode="rw",
-        read_permission=View,
-        write_permission=FieldEditSampler,
-        widget=StringWidget(
-            render_own_label=True,
-            size=20,
-            label=_("Collector"),
-            description=_("The practitioner who collected the sample"),
-            visible={
-                "add": "edit",
-            }
         )
     ),
 

--- a/src/palau/lims/monkeys/content/analysisrequest.py
+++ b/src/palau/lims/monkeys/content/analysisrequest.py
@@ -126,17 +126,3 @@ def setResultsInterpretationDepts(self, value):
 
         # set the field
         self.getField("ResultsInterpretationDepts").set(self, records)
-
-
-def getCollector(self):
-    """Returns the collector of the sample/specimen, if any
-    """
-    return self.getField("Collector").get(self)
-
-
-def setCollector(self, value):
-    """Returns the collector of the sample/specimen, if any
-    """
-    self.getField("Collector").set(self, value)
-    # Keep sampler field in-sync
-    self.getField("Sampler").set(self, value)

--- a/src/palau/lims/monkeys/content/analysisrequest.zcml
+++ b/src/palau/lims/monkeys/content/analysisrequest.zcml
@@ -68,16 +68,4 @@
       original="setResultsInterpretationDepts"
       replacement=".analysisrequest.setResultsInterpretationDepts"/>
 
-  <monkey:patch
-      class="bika.lims.content.analysisrequest.AnalysisRequest"
-      original="getCollector"
-      ignoreOriginal="True"
-      replacement=".analysisrequest.getCollector" />
-
-  <monkey:patch
-      class="bika.lims.content.analysisrequest.AnalysisRequest"
-      original="setCollector"
-      ignoreOriginal="True"
-      replacement=".analysisrequest.setCollector" />
-
 </configure>


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Requirements:
> - https://github.com/beyondessential/bes.lims/pull/68

This Pull Request migrates the Collector field extension from this product to [bes.lims](https://github.com/beyondessential/bes.lims) product.

## Current behavior

The logic for Collector field extension lives in this product.

## Desired behavior

The logic for Collector field extension does not live in this product.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
