### PR TITLE
Remove getDepartmentTitle patch for Analysis

### DIFF
--- a/src/palau/lims/monkeys/content/analysis.py
+++ b/src/palau/lims/monkeys/content/analysis.py
@@ -54,12 +54,3 @@ def setInterimFields(self, value):  # noqa CamelCase
                 interim.update({"value": choices.get("N", "")})
 
     self.getField("InterimFields").set(self, value)
-
-
-def getDepartmentTitle(self):
-    """Returns the title of the department the analysis is assigned to, if
-    any. It works as a metacolumn for analysis catalog
-    """
-    department = self.getDepartment()
-    if department:
-        return api.get_title(department)

--- a/src/palau/lims/monkeys/content/analysis.zcml
+++ b/src/palau/lims/monkeys/content/analysis.zcml
@@ -25,10 +25,4 @@
       original="setInterimFields"
       replacement=".analysis.setInterimFields" />
 
-  <monkey:patch
-      class="bika.lims.content.analysis.Analysis"
-      original="getDepartmentTitle"
-      ignoreOriginal="True"
-      replacement=".analysis.getDepartmentTitle" />
-
 </configure>


### PR DESCRIPTION
## Description

This Pull Request removes stale patch for `Analysis` function `getDepartmentTitle`, that was only used for statistical reports, that were ported earlier to `bes.lims`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
