### PR TITLE
Fix missing value for split length in ID Server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #271 Fix missing value for split length in ID Server
 - #265 Compatibility with bes.lims#83 (Add Tamanu ID field)
 - #253 Add ASTM consumer for Cepheid's GeneXpert
 - #261 Remove getDepartmentTitle patch for Analysis

--- a/src/palau/lims/config.py
+++ b/src/palau/lims/config.py
@@ -138,19 +138,19 @@ ID_FORMATTING = [
         "form": "{parent_ar_id}P{partition_count:01d}",
         "prefix": "analysisrequestpartition",
         "sequence_type": "",
-        "split-length": 2
+        "split_length": 2
     }, {
         "portal_type": "AnalysisRequestRetest",
         "form": "{parent_base_id}R{retest_count:01d}",
         "prefix": "analysisrequestretest",
         "sequence_type": "",
-        "split-length": 2
+        "split_length": 2
     }, {
         "portal_type": "AnalysisRequestSecondary",
         "form": "{parent_ar_id}S{secondary_count:01d}",
         "prefix": "analysisrequestsecondary",
         "sequence_type": "",
-        "split-length": 2
+        "split_length": 2
     }, {
         "portal_type": "Worksheet",
         "form": "WS{yymmdd}-{seq:02d}",

--- a/src/palau/lims/profiles/default/metadata.xml
+++ b/src/palau/lims/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1023</version>
+  <version>1024</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/palau/lims/upgrade/v01_00_000.py
+++ b/src/palau/lims/upgrade/v01_00_000.py
@@ -25,6 +25,7 @@ from bika.lims.api import security as sapi
 from bika.lims.interfaces import IVerified
 from palau.lims import logger
 from palau.lims import PRODUCT_NAME as product
+from palau.lims.config import ID_FORMATTING
 from palau.lims.config import PRIORITIES
 from bes.lims.tamanu.config import TAMANU_USER
 from palau.lims.setuphandlers import setup_behaviors
@@ -574,3 +575,51 @@ def disable_sampling_workflow(tool):
     setup.setSamplingWorkflowEnabled(False)
     setup.setScheduleSamplingEnabled(False)
     logger.info("Disable sampling workflow fields [DONE]")
+
+
+def fix_split_length(tool):
+    """Updates the ID Server's split_length parameter for the portal types
+    AnalysisRequestPartition, AnalysisRequestRetest, AnalysisRequestSecondary
+    """
+    logger.info("Fix ID Server's split length ...")
+    portal_types = [
+        "AnalysisRequestPartition",
+        "AnalysisRequestRetest",
+        "AnalysisRequestSecondary"
+    ]
+
+    # Group our formatting by portal_type
+    formatting = {}
+    for item in ID_FORMATTING:
+        portal_type = item.get("portal_type")
+        if portal_type not in portal_types:
+            continue
+        formatting[portal_type] = item
+
+    # Walk through setup's formatting and update
+    setup = api.get_setup()
+    new_formatting = []
+    for item in setup.getIDFormatting():
+        # do not update unless a formatting in config exists
+        portal_type = item.get("portal_type")
+        if portal_type not in formatting:
+            new_formatting.append(item)
+            continue
+
+        # do not update unless the split_length is not valid
+        split_length = item.get("split_length")
+        if api.to_int(split_length, default=-1) >= 0:
+            new_formatting.append(item)
+            continue
+
+        # do not update unless 'form' hasn't changed
+        new_item = formatting.get(portal_type)
+        if item.get("form") != new_item.get("form"):
+            new_formatting.append(item)
+            continue
+
+        # assign the formatting from configuration
+        new_formatting.append(new_item)
+
+    setup.setIDFormatting(new_formatting)
+    logger.info("Fix ID Server's split length [DONE]")

--- a/src/palau/lims/upgrade/v01_00_000.zcml
+++ b/src/palau/lims/upgrade/v01_00_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Fix ID's split length for partition, retest and secondary samples"
+      description="
+        Updates the ID server's split_length parameter for the portal types
+        AnalysisRequestPartition, AnalysisRequestRetest and
+        AnalysisRequestSecondary
+      "
+      source="1023"
+      destination="1024"
+      handler=".v01_00_000.fix_split_length"
+      profile="palau.lims:default"/>
+
+  <genericsetup:upgradeStep
       title="Disable sampling workflow fields from setup"
       description="Disable sampling workflow fields from setup"
       source="1022"


### PR DESCRIPTION
## Description

This Pull Request fixes missing values in the `split_length` subfield for the portal types `AnalysisRequestPartition`, `AnalysisRequestRetest`, and `AnalysisRequestSecondary`. The issue was identified after the changes introduced in https://github.com/senaite/senaite.core/pull/2821

## Current behavior

Error when "Save" button is clicked in Setup because of missing values in ID server

## Desired behavior

Error when "Save" button is clicked in Setup because of missing values in ID server

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
