### PR TITLE
Remove 'replaced by' line from invalid reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #281 Remove 'replaced by' line from invalid reports
 - #271 Fix missing value for split length in ID Server
 - #265 Compatibility with bes.lims#83 (Add Tamanu ID field)
 - #253 Add ASTM consumer for Cepheid's GeneXpert

--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -231,13 +231,6 @@
         <!-- Invalidated sample -->
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Sample has been invalidated due to erroneously published results</div>
-          <tal:invalidreport tal:define="child python:model.getRetest()"
-                             tal:condition="python:child">
-            <span i18n:translate="">This Sample has been replaced by</span>
-            <a tal:attributes="href child/absolute_url"
-               tal:content="child/getId"/>
-          </tal:invalidreport>
-        </div>
 
         <!-- Secondary sample -->
         <div class="alert alert-info" tal:condition="primary">

--- a/src/palau/lims/locales/en/LC_MESSAGES/palau.lims.po
+++ b/src/palau/lims/locales/en/LC_MESSAGES/palau.lims.po
@@ -482,10 +482,6 @@ msgstr ""
 msgid "This Sample has been invalidated due to erroneously published results"
 msgstr ""
 
-#: palau/lims/impress/reports/Default.pt:236
-msgid "This Sample has been replaced by"
-msgstr ""
-
 #: palau/lims/behaviors/patient.py:62
 #: palau/lims/browser/content/warddepartments.py:55
 #: palau/lims/browser/content/wards.py:54

--- a/src/palau/lims/locales/palau.lims.pot
+++ b/src/palau/lims/locales/palau.lims.pot
@@ -485,10 +485,6 @@ msgstr ""
 msgid "This Sample has been invalidated due to erroneously published results"
 msgstr ""
 
-#: palau/lims/impress/reports/Default.pt:236
-msgid "This Sample has been replaced by"
-msgstr ""
-
 #: palau/lims/behaviors/patient.py:62
 #: palau/lims/browser/content/warddepartments.py:55
 #: palau/lims/browser/content/wards.py:54


### PR DESCRIPTION
## Description
This PR update invalid/republished report alerts to remove the "This Sample has been replaced by" message

Linked issue: https://github.com/beyondessential/bes.lims/issues/110

## Current behavior
Republished invalid reports show: “This Sample has been replaced by <sample id>”.


## Desired behavior
Republished invalid reports should not show the replacement-sample message.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
