### PR TITLE
Render results interpretation tables in final PDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #282 Render results interpretation tables in final PDF
 - #271 Fix missing value for split length in ID Server
 - #265 Compatibility with bes.lims#83 (Add Tamanu ID field)
 - #253 Add ASTM consumer for Cepheid's GeneXpert

--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -131,6 +131,14 @@
      .report .section-resultsinterpretation, .report .section-signatures {
        font-size: 90%;
      }
+     .report .section-resultsinterpretation table {
+       border-collapse: collapse;
+       width: 100%;
+     }
+     .report .section-resultsinterpretation table td, .report .section-resultsinterpretation table th {
+       border: 1px solid #999;
+       padding: 0.2rem;
+     }
      .report .section-signatures {
        border-top:2px solid black;
        padding-top:10px;


### PR DESCRIPTION
## Description
This PR fixes the rendering of the final report's richtext tables for results interpretation.

Linked issue: https://github.com/beyondessential/bes.lims/issues/112

## Current behavior
- In sample view,  results interpretation richtext shows table content.
- In the final report PDF, the same interpretation table is not rendered as expected.

## Desired behavior
- Results interpretation richtext tables render in the final report/PDF the same way as in the sample view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
