### PR TITLE
Add senaite.panic dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #286 Add senaite.panic dependency
 - #283 Update preliminary report conditions for not invalidated and provisional samples
 - #282 Render results interpretation tables in final PDF
 - #281 Remove 'replaced by' line from invalid reports

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "bes.lims>=1.0.0",
+        "senaite.panic>=2.1.0",
         "senaite.storage>=2.6.0",
     ],
     extras_require={

--- a/src/palau/lims/profiles/default/metadata.xml
+++ b/src/palau/lims/profiles/default/metadata.xml
@@ -11,6 +11,7 @@
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>
     <dependency>profile-bes.lims:default</dependency>
+    <dependency>profile-senaite.panic:default</dependency>
     <dependency>profile-senaite.storage:default</dependency>
   </dependencies>
 


### PR DESCRIPTION
## Description

This Pull Request adds the `senaite.panic` add-on as a dependency

Issue: https://github.com/beyondessential/palau.lims/issues/285


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
