### PR TITLE
Fix All reports being saved as one PDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #288 Fix All reports being saved as one PDF
 - #286 Add senaite.panic dependency
 - #283 Update preliminary report conditions for not invalidated and provisional samples
 - #282 Render results interpretation tables in final PDF

--- a/src/palau/lims/impress/reports/Default.pt
+++ b/src/palau/lims/impress/reports/Default.pt
@@ -240,7 +240,7 @@
         <!-- Invalidated sample -->
         <div class="alert alert-danger" tal:condition="invalidated">
           <div i18n:translate="">This Sample has been invalidated due to erroneously published results</div>
-
+        </div>
         <!-- Secondary sample -->
         <div class="alert alert-info" tal:condition="">
           <div>


### PR DESCRIPTION
## Description

Linked issue: #287 

## Current behavior

A single PDF with all results reports is generated when publishing multiple samples

## Desired behavior

A single PDF for each sample is generated when publishing multiple samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
