### PR TITLE
Compatibility with core#2810 (Laboratory to DX)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.0 (Unreleased)
 ------------------
 
+- #293 Compatibility with core#2810 (Laboratory to DX)
 - #288 Fix All reports being saved as one PDF
 - #286 Add senaite.panic dependency
 - #283 Update preliminary report conditions for not invalidated and provisional samples

--- a/src/palau/lims/browser/sample/rejection.py
+++ b/src/palau/lims/browser/sample/rejection.py
@@ -21,6 +21,7 @@
 import copy
 from datetime import datetime
 
+from bes.lims.utils import get_laboratory
 from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.utils import createPdf
@@ -65,7 +66,7 @@ class RejectionView(BrowserView):
     def laboratory(self):
         """Returns a supermodel of the LIMS's laboratory object
         """
-        laboratory = api.get_setup().laboratory
+        laboratory = get_laboratory()
         return SuperModel(laboratory)
 
     @property

--- a/src/palau/lims/setuphandlers.py
+++ b/src/palau/lims/setuphandlers.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2023-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+from bes.lims.utils import get_laboratory
 from bika.lims import api
 from bika.lims.browser.analysisrequest.add2 import AR_CONFIGURATION_STORAGE
 from BTrees.OOBTree import OOBTree
@@ -314,8 +314,7 @@ def setup_laboratory(portal):
     """Setup Laboratory
     """
     logger.info("Setup Laboratory ...")
-    setup = api.get_setup()
-    lab = setup.laboratory
+    lab = get_laboratory()
     api.edit(lab, check_permissions=False, **dict(LABORATORY_SETTINGS))
     logger.info("Setup Laboratory [DONE]")
 


### PR DESCRIPTION
## Description

This Pull Request makes this product compatible with [Migrate Laboratory to DX #2810](https://github.com/senaite/senaite.core/pull/2810)

> [!IMPORTANT]
> Requires: 
> - https://github.com/beyondessential/bes.lims/pull/152

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
